### PR TITLE
add missing repo url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ The client methods map directly to the Novu API endpoints. Here's a list of all 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://
+Bug reports and pull requests are welcome on GitHub at https://github.com/novuhq/novu-ruby


### PR DESCRIPTION
url missing in last line of readme: 
```md
Bug reports and pull requests are welcome on GitHub at https://
```
