### PR TITLE
Add Environment Variable for Custom API URL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    json (2.6.3)
     json (2.6.3-java)
     method_source (1.0.0)
     mini_mime (1.1.2)
@@ -89,6 +90,7 @@ GEM
 
 PLATFORMS
   universal-java-17
+  x86_64-linux
 
 DEPENDENCIES
   novu!
@@ -99,4 +101,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.4.1
+   2.4.18

--- a/lib/novu/client.rb
+++ b/lib/novu/client.rb
@@ -35,7 +35,7 @@ module Novu
     include Novu::Api::Subscribers
     include Novu::Api::Topics
 
-    base_uri "https://api.novu.co/v1"
+    base_uri ENV.fetch("NOVU_BASE_API_URL", "https://api.novu.co/v1")
     format :json
 
     def initialize(access_token = nil)


### PR DESCRIPTION
This will allow users with Self-hosted Novu being able to define theirs Custom URL through `NOVU_BASE_API_URL` Environment Variable. Without define it while Novu Object Creation. e,g: `notification = Novu::Client.new('custom://local.url', <api_key>')`