### PR TITLE
add bulk subscribers creation api

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ body = {
 client.update_subscriber_preference('<insert-subscriber-id>', '<insert-template-id>', body)
 ```
 
-- Create bulk subscribers: `create_bulk_subscribers(body)`
+- Create bulk subscribers: `bulk_create_subscribers(body)`
 ```ruby
 payload = {
     'subscribers' => [
@@ -663,7 +663,7 @@ payload = {
         }
     ]
 }
-client.create_bulk_subscribers(payload)
+client.bulk_create_subscribers(payload)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -614,6 +614,32 @@ body = {
 client.update_subscriber_preference('<insert-subscriber-id>', '<insert-template-id>', body)
 ```
 
+- Create bulk subscribers: `create_bulk_subscribers(body)`
+```ruby
+payload = {
+    'subscribers' => [
+        {
+            'name' => 'subscriber-1',
+            'email' => 'user1@example.com',
+            'firstName' => 'test1',
+            'lastName' => 'test1',
+            'phone' => '08122442244',
+            'subscriberId' => 'subscriber-test-1221'
+        },
+        {
+            'name' => 'subscriber2',
+            'email' => 'user2@example.com',
+            'firstName' => 'test2',
+            'lastName' => 'test2',
+            'phone' => '0814422334',
+            'subscriberId' => 'subscriber-test-9090'
+        }
+    ]
+}
+client.create_bulk_subscribers(payload)
+```
+
+
 - Get in-app notification feed for a particular subscriber: `subscriber_notification_feed(subscriber_id, query = {})`
 
 ```ruby

--- a/lib/novu/api/subscribers.rb
+++ b/lib/novu/api/subscribers.rb
@@ -209,7 +209,7 @@ module Novu
         post("/subscribers/#{subscriber_id}/messages/#{message_id}/actions/#{type}")
       end
 
-			# Using this endpoint you can trigger multiple events at once, to avoid multiple calls to the API.
+			# Using this endpoint you can create multiple subscribers at once, to avoid multiple calls to the API.
       # The bulk API is limited to 500 subscribers per request.
       #
       # @bodyparams:

--- a/lib/novu/api/subscribers.rb
+++ b/lib/novu/api/subscribers.rb
@@ -208,6 +208,31 @@ module Novu
       def mark_message_action_seen(subscriber_id, message_id, type)
         post("/subscribers/#{subscriber_id}/messages/#{message_id}/actions/#{type}")
       end
+
+			# Using this endpoint you can trigger multiple events at once, to avoid multiple calls to the API.
+      # The bulk API is limited to 500 subscribers per request.
+      #
+      # @bodyparams:
+      # @param `subscribers` [Array[subscriber]]
+      #     @subscriber : subscriber structure
+      #     @param `firstName` [Stringoptional)] The first name of the subscriber.
+      #     @param `lastName` [Stringoptional)] The last name of the subscriber.
+      #     @param `email` [Stringoptional)] The email of the subscriber.
+      #     @param `data` [Hash(optional)] The data object is used to pass additional custom information that could be used to identify the subscriber.
+      #     @param `phone` [Hash(optional)] This phone of the subscriber.
+      #     @param `locale` [String(optional)] The location of the subscriber.
+      #     @param `subscriberId` [String] A unique identifier for the subscriber, usually correlates to the id the user in your systems.
+      #     @param `avatar` [String(optional)] An http url to the profile image of your subscriber
+			#
+      # @return data [Hash]
+      #   - updated [Array] - If the subscriber was updated
+      #   - created [Array] - Array of objects for the subsribers ID created
+      #   - failed [Array] - In case of an error, this field will contain the error message
+      #   
+      # @return [number] status - The status code. Returns 201 if the subscribers were created successfully.
+			def create_bulk_subscribers(body)
+        post("/subscribers/bulk", body: body.to_json, headers: {'Content-Type': 'application/json'})
+			end
     end
   end
 end

--- a/spec/subscribers_spec.rb
+++ b/spec/subscribers_spec.rb
@@ -306,4 +306,48 @@ RSpec.describe Novu::Api::Subscribers do
       expect(result.code).to eq(201)
     end
   end
+
+  describe "#create_bulk_subscribers" do
+    it "create bulk subscribers" do
+			body = {
+        subscribers: [
+					{
+						'name' => 'subscriber-1',
+						'email' => 'user1@example.com',
+						'firstName' => 'test1',
+						'lastName' => 'test1',
+						'phone' => '08122442244',
+						'subscriberId' => 'subscriber-test-1221'
+					},
+					{
+						'name' => 'subscriber2',
+						'email' => 'user2@example.com',
+						'firstName' => 'test2',
+						'lastName' => 'test2',
+						'phone' => '0814422334',
+						'subscriberId' => 'subscriber-test-9090'
+					}
+        ]
+      }
+
+      response_body = {
+        data: {
+					failed: [],
+					updated: [],
+					created: [
+						{ subscriberId: 'subscriber-test-1221'},
+						{ subscriberId: 'subscriber-test-9090'},
+					]
+				}
+      }.to_json
+
+      stub_request(:post, "#{base_uri}/subscribers/bulk")
+        .with(body: body).to_return(status: 201, body: response_body)
+
+      result = client.create_bulk_subscribers(body)
+
+      expect(result.body).to eq(response_body)
+      expect(result.code).to eq(201)
+		end
+	end
 end


### PR DESCRIPTION
This PR adds the functionality to create multiple subscribers at once.
Use Case: 
```ruby
payload = {
    'subscribers' => [
        {
            'name' => 'subscriber-1',
            'email' => 'user1@example.com',
            'firstName' => 'test1',
            'lastName' => 'test1',
            'phone' => '08122442244',
            'subscriberId' => 'subscriber-test-1221'
        },
        {
            'name' => 'subscriber2',
            'email' => 'user2@example.com',
            'firstName' => 'test2',
            'lastName' => 'test2',
            'phone' => '0814422334',
            'subscriberId' => 'subscriber-test-9090'
        }
    ]
}
client.create_bulk_subscribers(payload)
```