### PR TITLE
Refactor/add missing api methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,12 @@ client.channel_limit('<insert-channel-type>')
 client.in_app_status()
 ```
 
+- Set integration as primary: `set_integration_as_primary(integration_id)`
+
+```ruby
+client.set_integration_as_primary('<insert-integration-id>')
+```
+
 
 ### Layouts
 

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ client.notification('<insert-notification-id>')
 client.subscribers({
     'page' => 1, # optional
     'limit' => 15, # optional
-})
+}) 
 ```
 
 - Create subscriber: `create_subscriber(body)`
@@ -609,6 +609,12 @@ body = {
     } 
 }
 client.update_subscriber_credentials('<insert-subscriber-id>', body)
+```
+
+- Delete subscriber credentials by providerId: `delete_subscriber_credentials(subscriberId, providerId)`
+
+```ruby
+client.delete_subscriber_credentials('<insert-subscriber-id>', '<insert-provider-id>')
 ```
 
 - Update subscriber online status: `update_subscriber_online_status(subscriber_id, body)`
@@ -671,6 +677,36 @@ client.mark_subscriber_feed_seen('<insert-subscriber-id>', {
 
 ```ruby
 client.mark_message_action_seen('<insert-subscriber-id>', '<insert-message-id>', '<insert-type>')
+```
+
+- Marks all the subscriber messages: `mark_all_subscriber_messages(subscriber_id, body)`
+
+```ruby
+body = {
+  'markAs' => 'seen'
+}
+client.mark_all_subscriber_messages('<insert-subscriber-id>', body)
+```
+
+- Handle providers OAUTH redirect: `provider_oauth_redirect(subscriber_id, provider_id, query)`
+```ruby
+query = {
+  'environmentId' => '<insert-environment-id>',
+    'code' => '<insert-code>',
+    'hmacHash' => '<insert-hmacHash>',
+    'integrationIdentifier' => '<insert-integration-identifier>'
+}
+client.provider_oauth_redirect('<insert-subscriber-id>', '<insert-provider-id>', query)
+```
+
+- Handle chat OAUTH: `chat_oauth(subscriber_id, provider_id, query)`
+```ruby
+query = {
+  'environmentId' => '<insert-environment-id>',
+    'hmacHash' => '<insert-hmacHash>',
+    'integrationIdentifier' => '<insert-integration-identifier>'
+}
+client.chat_oauth('<insert-subscriber-id>', '<insert-provider-id>', query)
 ```
 
 ### Tenants

--- a/README.md
+++ b/README.md
@@ -692,9 +692,9 @@ client.mark_all_subscriber_messages('<insert-subscriber-id>', body)
 ```ruby
 query = {
   'environmentId' => '<insert-environment-id>',
-    'code' => '<insert-code>',
-    'hmacHash' => '<insert-hmacHash>',
-    'integrationIdentifier' => '<insert-integration-identifier>'
+  'code' => '<insert-code>',
+  'hmacHash' => '<insert-hmacHash>',
+  'integrationIdentifier' => '<insert-integration-identifier>'
 }
 client.provider_oauth_redirect('<insert-subscriber-id>', '<insert-provider-id>', query)
 ```
@@ -703,8 +703,8 @@ client.provider_oauth_redirect('<insert-subscriber-id>', '<insert-provider-id>',
 ```ruby
 query = {
   'environmentId' => '<insert-environment-id>',
-    'hmacHash' => '<insert-hmacHash>',
-    'integrationIdentifier' => '<insert-integration-identifier>'
+  'hmacHash' => '<insert-hmacHash>',
+  'integrationIdentifier' => '<insert-integration-identifier>'
 }
 client.chat_oauth('<insert-subscriber-id>', '<insert-provider-id>', query)
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ client.changes({
 ```ruby
 client.count_changes()
 ```
+
 - Apply changes: `apply_bulk_changes()`
 ```ruby
 client.apply_change({

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ client.notifications
 
 The client methods map directly to the Novu API endpoints. Here's a list of all the available methods. Check [the API docs](https://docs.novu.co/api/overview) for list of available `methods`.
 
+### Blueprints
+
+- Get V1blueprints: `get_blueprint(template_id)`
+
+```ruby
+client.get_blueprint('<insert-template-id>')
+```
+
+- Get V1blueprints by category: `group_blueprints_by_category()`
+
+```ruby
+client.group_blueprints_by_category()
+```
+
 ### Changes
 
 - Get changes: `changes(query = {})`
@@ -70,7 +84,7 @@ client.count_changes()
 
 - Apply changes: `apply_bulk_changes()`
 ```ruby
-client.apply_change({
+client.apply_bulk_changes({
     'changeIds' => ['<insert-all-the-change-ids>']
 })
 ```

--- a/README.md
+++ b/README.md
@@ -767,6 +767,18 @@ client.rename_topic('<insert-topic-key>', {
 })
 ```
 
+- Delete topic: `delete_topic(topic_key)`
+
+```ruby
+client.delete_topic('<insert-topic-key>')
+```
+
+- Check topic subsriber: `subscriber_topic(topic_key, externalSubscriberId)`
+
+```ruby
+client.subscriber_topic('<insert-topic-key>', '<insert-externalSubscriberId>')
+```
+
 ### For more information about these methods and their parameters, see the [API documentation](https://docs.novu.co/api-reference).
 
 ## Contributing

--- a/lib/novu/api/blueprints.rb
+++ b/lib/novu/api/blueprints.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Novu
+  class Api
+    # Module Novu::Api::Blueprints provides an API for managing templated for notifications that are sent out in the Novu application.
+    #
+    # This module includes methods for retrieving blueprints by templateID and grouping blueprints by category.
+    #
+    # For more information on the Novu Blueprint API, see https://docs.novu.co/api/get-messages/.
+    module Blueprints
+      # Returns the details of a particular template
+      #
+      # @pathParams 
+      # @param `template_id` [String]
+      #
+      # @return [Hash] The list of properties that pertains to the template e.g. _id, name, description, active, draft, preferenceSettings, and many others.
+      # @return [number] status
+      #  - Returns 200 if successful
+      def get_blueprint(template_id)
+        get("/blueprints/#{template_id}")
+      end
+
+      # Get V1blueprintsgroup by Category
+      def group_blueprints_by_category
+        get("/blueprints/group-by-category")
+      end
+    end
+  end
+end

--- a/lib/novu/api/changes.rb
+++ b/lib/novu/api/changes.rb
@@ -33,11 +33,13 @@ module Novu
 
       # Apply Bulk Change
       #
+      # @bodyParams
+      # @param changeIds [Array] The list of environment IDs to apply changes to.
       # @return [Hash] updated change.
       # @return [number] status
       #  - Returns 201 if the bulk change has been updated correctly.
-      def apply_bulk_changes
-        post("/changes/bulk/apply")
+      def apply_bulk_changes(changeIds)
+        post("/changes/bulk/apply", body: changeIds)
       end
 
       # Apply change

--- a/lib/novu/api/integrations.rb
+++ b/lib/novu/api/integrations.rb
@@ -100,6 +100,17 @@ module Novu
       def in_app_status
         get("/integrations/in-app/status")
       end
+
+      # Set integration as primary
+      #
+      # @pathparams
+      # @param `integration_id` [String]
+      # 
+      # @return [number] status
+      #  - Returns 200 if successful
+      def set_integration_as_primary(integration_id)
+        post("/integrations/#{integration_id}/set-primary")
+      end
     end
   end
 end

--- a/lib/novu/api/subscribers.rb
+++ b/lib/novu/api/subscribers.rb
@@ -45,7 +45,7 @@ module Novu
       # Retrieves the subscriber with the given ID.
       #
       # @pathparams
-      # @param `subscribe_id` [String] The ID of the subscriber to retrieve.
+      # @param `subscriber_id` [String] The ID of the subscriber to retrieve.
       #
       # @return [Hash] The retrieved subscriber.
       # @return [number] status
@@ -101,6 +101,19 @@ module Novu
       #  - Returns 200 if the subscriber credentials has been updated correctly.
       def update_subscriber_credentials(subscriber_id, body)
         put("/subscribers/#{subscriber_id}/credentials", body: body)
+      end
+
+      # Delete subscriber credentials by providerId
+      # Delete subscriber credentials such as slack and expo tokens.
+      #
+      # @pathParams:
+      # @param `subscriberId` [String] The ID of the subscriber to update credentials.
+      # @param `providerId` [String] The provider identifier for the credentials
+      #
+      # @return [number] status
+      #  - Returns 204 if the subscriber credentials has been deleted successfully.
+      def delete_subscriber_credentials(subscriberId, providerId)
+        delete("/subscribers/#{subscriberId}/credentials/#{providerId}")
       end
 
       # Used to update the subscriber isOnline flag.
@@ -207,6 +220,57 @@ module Novu
       #  - Returns 201 if successful
       def mark_message_action_seen(subscriber_id, message_id, type)
         post("/subscribers/#{subscriber_id}/messages/#{message_id}/actions/#{type}")
+      end
+
+      # Marks all the subscriber messages as read, unread, seen or unseen.
+      # 
+      # @pathparams
+      # @param `subscriber_id` [String]
+      # 
+      # @bodyParams:
+      # @param `markAs` [String] The type of action to perform either read, unread, seen or unseen.
+      # @param `feedIdentifier` [String|Array(Optional)]  The feed id (or array) to mark messages of a particular feed.
+      #
+      # @return [number] status
+      #  - Returns 201 if successful
+      def mark_all_subscriber_messages(subscriber_id, body)
+        post("/subscribers/#{subscriber_id}/messages/mark-all", body: body)
+      end
+
+      # Handle providers OAUTH redirect
+      #
+      # @pathparams:
+      # @param `subscriberId` [String]
+      # @param `providerId` [String]
+      #
+      # @queryparams:
+      # @param `code` [String]
+      # @param `hmacHash` [String]
+      # @param `environmentId` [String]
+      # @param `integrationIdentifier` [String]
+      #
+      # @return [Hash] The list of changes that match the criteria of the query params are successfully returned.
+      # @return [number] status
+      #  - Returns 200 if successful
+      def provider_oauth_redirect(subscriberId, providerId, query = {})
+        get("/subscribers/#{subscriberId}/credentials/#{providerId}/oauth/callback", query: query)
+      end
+
+      # Handle chat OAUTH
+      #
+      # @pathparams:
+      # @param `subscriberId` [String]
+      # @param `providerId` [String]
+      #
+      # @queryparams:
+      # @param `hmacHash` [String]
+      # @param `environmentId` [String]
+      # @param `integrationIdentifier` [String]
+      #
+      # @return [number] status
+      #  - Returns 200 if successful
+      def chat_oauth(subscriberId, providerId, query = {})
+        get("/subscribers/#{subscriberId}/credentials/#{providerId}/oauth", query: query)
       end
     end
   end

--- a/lib/novu/api/topics.rb
+++ b/lib/novu/api/topics.rb
@@ -61,6 +61,18 @@ module Novu
         post("/topics/#{topic_key}/subscribers/removal", body: body)
       end
 
+      # Check topic subsriber
+      # Check if a subscriber belongs to a certain topic
+      #
+      # @pathparams
+      # @param `topic_key` [String]
+      # @param `externalSubscriberId` [String] The id of the subscriber created on `/subscribers` endpoint
+      #
+      # @return [number] status - The status code. Returns 200 if subscriber was added to the topic.
+      def subscriber_topic(topic_key, externalSubscriberId)
+        get("/topics/#{topic_key}/subscribers/#{externalSubscriberId}")
+      end
+
       # Get a topic by its topic key
       #
       # @pathparams

--- a/lib/novu/api/topics.rb
+++ b/lib/novu/api/topics.rb
@@ -99,6 +99,17 @@ module Novu
       def rename_topic(topic_key, body)
         patch("/topics/#{topic_key}", body: body)
       end
+
+      # Delete topic
+      # Delete a topic by its topic key if it has no subscribers
+      #
+      # @pathparams
+      # @param `topic_key` [String]
+      #
+      # @return [number] status - The status code. Returns 204 if successfully deleted topic.
+      def delete_topic(topic_key)
+        delete("/topics/#{topic_key}")
+      end
     end
   end
 end

--- a/lib/novu/client.rb
+++ b/lib/novu/client.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "novu/api/blueprints"
 require "novu/api/changes"
 require "novu/api/connection"
 require "novu/api/environments"
@@ -20,6 +21,7 @@ require "novu/api/topics"
 module Novu
   class Client
     include HTTParty
+    include Novu::Api::Blueprints
     include Novu::Api::Changes
     include Novu::Api::Connection
     include Novu::Api::Environments

--- a/spec/blueprints_spec.rb
+++ b/spec/blueprints_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../lib/novu"
+
+RSpec.describe Novu::Api::Blueprints do
+  let(:access_token) { "1234567890" }
+  let(:client) { Novu::Client.new(access_token) }
+  let(:base_uri) { "https://api.novu.co/v1" }
+
+  describe "#get_blueprint" do
+    it "returns the details of a particular template " do
+      template_id = "12345"
+
+      response_body = {
+        _id: "template_id"
+      }.to_json
+
+      stub_request(:get, "#{base_uri}/blueprints/#{template_id}")
+        .to_return(status: 200, body: response_body)
+
+      result = client.get_blueprint(template_id)
+
+      expect(result.body).to eq(response_body)
+      expect(result.code).to eq(200)
+    end
+  end
+
+  describe "#group_blueprints_by_category" do
+    it "return blueprints and group by category" do
+      message_id = "12345"
+      response_body = {
+          "general": [
+            "object"
+          ],
+          "popular": "object"
+      }.to_json
+
+      stub_request(:get, "#{base_uri}/blueprints/group-by-category")
+        .to_return(status: 200, body: response_body)
+
+      result = client.group_blueprints_by_category()
+
+      expect(result.body).to eq(response_body)
+      expect(result.code).to eq(200)
+    end
+  end
+end

--- a/spec/blueprints_spec.rb
+++ b/spec/blueprints_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Novu::Api::Blueprints do
       template_id = "12345"
 
       response_body = {
-        _id: "template_id"
+        _id: "string"
       }.to_json
 
       stub_request(:get, "#{base_uri}/blueprints/#{template_id}")

--- a/spec/changes_spec.rb
+++ b/spec/changes_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe Novu::Api::Changes do
 
   describe "#apply_bulk_changes" do
     it "apply bulk change" do
+      payload = {
+        'changeIds' => ['64a865672']
+      }
+
       response_body = {
         _id: "string",
         _creatorId: "string"
@@ -56,7 +60,7 @@ RSpec.describe Novu::Api::Changes do
       stub_request(:post, "#{base_uri}/changes/bulk/apply")
         .to_return(status: 201, body: response_body)
 
-      result = client.apply_bulk_changes
+      result = client.apply_bulk_changes(payload)
 
       expect(result.body).to eq(response_body)
       expect(result.code).to eq(201)

--- a/spec/changes_spec.rb
+++ b/spec/changes_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Novu::Api::Changes do
         "pageSize": 10,
         "data": [
           {
-            "_id": "63f71b3ef067290fa669106d"
+            "_id": "string"
           }
         ]
       }.to_json
@@ -49,7 +49,7 @@ RSpec.describe Novu::Api::Changes do
   describe "#apply_bulk_changes" do
     it "apply bulk change" do
       payload = {
-        'changeIds' => ['64a865672']
+        'changeIds' => ['string']
       }
 
       response_body = {

--- a/spec/integrations_spec.rb
+++ b/spec/integrations_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Novu::Api::Integrations do
       }.to_json
 
       response_body = {
-        _id: "63f71b3ef067290fa669106d"
+        _id: "string"
       }.to_json
 
       stub_request(:post, "#{base_uri}/integrations")
@@ -79,7 +79,7 @@ RSpec.describe Novu::Api::Integrations do
 
   describe "#update_integration" do
     it "update the credentials of a integration." do
-      integration_id = "63f71b3ef067290fa669106d"
+      integration_id = "string"
 
       body = {
         active: true,
@@ -148,9 +148,9 @@ RSpec.describe Novu::Api::Integrations do
 
   describe "#set_integration_as_primary" do
     it "sets an integration as primary" do
-      integration_id = "63f71b3ef067290fa669106d"
+      integration_id = "string"
       response_body = {
-        _id: "63f71b3ef067290fa669106d"
+        _id: "string"
       }.to_json
       
       stub_request(:post, "#{base_uri}/integrations/#{integration_id}/set-primary")

--- a/spec/integrations_spec.rb
+++ b/spec/integrations_spec.rb
@@ -145,4 +145,21 @@ RSpec.describe Novu::Api::Integrations do
       expect(result.code).to eq(200)
     end
   end
+
+  describe "#set_integration_as_primary" do
+    it "sets an integration as primary" do
+      integration_id = "63f71b3ef067290fa669106d"
+      response_body = {
+        _id: "63f71b3ef067290fa669106d"
+      }.to_json
+      
+      stub_request(:post, "#{base_uri}/integrations/#{integration_id}/set-primary")
+        .to_return(status: 200, body: response_body)
+
+      result = client.set_integration_as_primary(integration_id)
+
+      expect(result.body).to eq(response_body)
+      expect(result.code).to eq(200)
+    end
+  end
 end

--- a/spec/subscribers_spec.rb
+++ b/spec/subscribers_spec.rb
@@ -159,6 +159,17 @@ RSpec.describe Novu::Api::Subscribers do
     end
   end
 
+  describe "#delete_subscriber_credentials" do
+    it "#Delete subscriber credentials such as slack and expo tokens." do
+      providerId = 'slack'
+      
+      stub_request(:delete, "#{base_uri}/subscribers/#{subscriber_id}/credentials/#{providerId}")
+        .to_return(status: 204)
+
+      result = client.delete_subscriber_credentials(subscriber_id, providerId)
+    end
+  end
+
   describe "#update_subscriber_online_status" do
     it "update subscriber online status" do
       body = {
@@ -301,6 +312,67 @@ RSpec.describe Novu::Api::Subscribers do
         .to_return(status: 201, body: response_body)
 
       result = client.mark_message_action_seen(subscriber_id, message_id, type)
+
+      expect(result.body).to eq(response_body)
+      expect(result.code).to eq(201)
+    end
+  end
+
+  describe "#mark_all_subscriber_messages" do
+    it "mark all subscriber messages" do
+      payload = {
+        'markAs' => 'seen'
+      }
+      response_body = "number"
+
+      stub_request(:post, "#{base_uri}/subscribers/#{subscriber_id}/messages/mark-all")
+        .with(body: payload)
+        .to_return(status: 201, body: response_body)
+
+      result = client.mark_all_subscriber_messages(subscriber_id, payload)
+
+      expect(result.body).to eq(response_body)
+      expect(result.code).to eq(201)
+    end
+  end
+
+  describe "#provider_oauth_redirect" do
+    it "Handle providers OAUTH redirect" do
+      providerId = 'slack'
+      payload = {
+        'environmentId' => '64a865672712f97fb0985298',
+        'code' => '123',
+        'hmacHash' => '$2y$10$U',
+        'integrationIdentifier' => 'integration'
+      }
+      response_body = "object"
+
+      stub_request(:get, "#{base_uri}/subscribers/#{subscriber_id}/credentials/#{providerId}/oauth/callback")
+        .with(query: payload)
+        .to_return(status: 201, body: response_body)
+
+      result = client.provider_oauth_redirect(subscriber_id, providerId, payload)
+
+      expect(result.body).to eq(response_body)
+      expect(result.code).to eq(201)
+    end
+  end
+
+  describe "#chat_oauth" do
+    it "Handle chat OAUTH" do
+      providerId = 'slack'
+      payload = {
+        'environmentId' => '64a865672712f97fb0985298',
+        'hmacHash' => '$2y$10$U.lIU/phf4',
+        'integrationIdentifier' => 'integration'
+      }
+      response_body = "object"
+
+      stub_request(:get, "#{base_uri}/subscribers/#{subscriber_id}/credentials/#{providerId}/oauth")
+        .with(query: payload)
+        .to_return(status: 201, body: response_body)
+
+      result = client.chat_oauth(subscriber_id, providerId, payload)
 
       expect(result.body).to eq(response_body)
       expect(result.code).to eq(201)

--- a/spec/topics_spec.rb
+++ b/spec/topics_spec.rb
@@ -165,4 +165,16 @@ RSpec.describe Novu::Api::Topics do
       expect(result.code).to eq(200)
     end
   end
+
+  describe "#delete_topic" do
+    it "delete a topic by its topic key if it has no subscribers" do
+      
+
+      stub_request(:delete, "#{base_uri}/topics/#{topic_key}")
+        .to_return(status: 204)
+
+      result = client.delete_topic(topic_key)
+      expect(result.code).to eq(204)
+    end
+  end
 end

--- a/spec/topics_spec.rb
+++ b/spec/topics_spec.rb
@@ -114,6 +114,19 @@ RSpec.describe Novu::Api::Topics do
     end
   end
 
+  describe "#subscriber_topic" do
+    it "Check if a subscriber belongs to a certain topic" do
+      body = ""
+
+      stub_request(:get, "#{base_uri}/topics/#{topic_key}/subscribers/string")
+        .to_return(status: 200)
+
+      result = client.subscriber_topic(topic_key, 'string')
+      expect(result.body).to eq(body)
+      expect(result.code).to eq(200)
+    end
+  end
+
   describe "#topic" do
     it "returns the specified topic by its topic key" do
       response_body = {


### PR DESCRIPTION
The following endpoints have the added to the SDK:

- delete_subscriber_credentials
- get_blueprint
- group_blueprints_by_category
- set_integration_as_primary
- delete_subscriber_credentials
- mark_all_subscriber_messages
- provider_oauth_redirect
- chat_oauth
- delete_topic
- subscriber_topic