### PR TITLE
fix: set the gemspec version using the release tag value

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish new Novu Ruby SDK release to Ruby Gems
 
 on:
   release:
@@ -22,6 +22,8 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          sed -i "s/spec.version = \".*\"/spec.version = \"${{ steps.get_version.outputs.VERSION }}\"/g" *.gemspec
+          echo "spec.version variable replaced with '${{ steps.get_version.outputs.VERSION }}'"
           gem build *.gemspec
           gem push *.gem
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Get the release version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR updates the `release.yml` to include a step to automatically sets the version of the SDK to be published using the value of the release tag.