### PR TITLE
fix: update gemfile.lock to accommodate different platfrom architecture

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,4 @@ end
 
 gem "rubocop", "~> 1.21"
 
-gem 'pry-debugger-jruby'
+# gem 'pry-debugger-jruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,33 +17,24 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    ffi (1.15.5-java)
     hashdiff (1.0.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    json (2.6.3)
     json (2.6.3-java)
-    method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.17.0)
     multi_xml (0.6.0)
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
-    pry (0.14.2-java)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-      spoon (~> 0.0)
-    pry-debugger-jruby (2.1.1-java)
-      pry (>= 0.13, < 0.15)
-      ruby-debug-base (>= 0.10.4, < 0.12)
     public_suffix (5.0.1)
     rainbow (3.1.1)
     rake (13.0.6)
@@ -74,10 +65,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.27.0)
       parser (>= 3.2.1.0)
-    ruby-debug-base (0.11.0-java)
     ruby-progressbar (1.11.0)
-    spoon (0.0.6)
-      ffi
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -88,11 +76,14 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  ruby
+  universal-java-11
   universal-java-17
+  x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   novu!
-  pry-debugger-jruby
   rake (~> 13.0)
   rspec
   rubocop (~> 1.21)


### PR DESCRIPTION
This PR does the following:
1. Added more platform dependencies in the `gemfile.lock` file
2. Removed `pry-debugger-jruby` because it's use is redundant in the SDK