### PR TITLE
Feat: Add Exponential Retry Mechanism with Idempotency Headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test do
 end
 
 gem "exponential-backoff"
+gem 'mocha'
 gem "rubocop", "~> 1.21"
 gem 'uuid', '~> 2.3', '>= 2.3.9'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ group :test do
   gem "webmock"
 end
 
+gem "exponential-backoff"
 gem "rubocop", "~> 1.21"
+gem 'uuid', '~> 2.3', '>= 2.3.9'
 
 # gem 'pry-debugger-jruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
+    exponential-backoff (0.0.4)
     hashdiff (1.0.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
@@ -29,6 +30,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     json (2.6.3-java)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
     mini_mime (1.1.2)
     minitest (5.17.0)
     multi_xml (0.6.0)
@@ -66,9 +69,12 @@ GEM
     rubocop-ast (1.27.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.11.0)
+    systemu (2.6.5)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    uuid (2.3.9)
+      macaddr (~> 1.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -83,10 +89,12 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  exponential-backoff
   novu!
   rake (~> 13.0)
   rspec
   rubocop (~> 1.21)
+  uuid (~> 2.3, >= 2.3.9)
   webmock
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,8 @@ GEM
       systemu (~> 2.6.5)
     mini_mime (1.1.2)
     minitest (5.17.0)
+    mocha (2.1.0)
+      ruby2_keywords (>= 0.0.5)
     multi_xml (0.6.0)
     parallel (1.22.1)
     parser (3.2.1.0)
@@ -69,6 +71,7 @@ GEM
     rubocop-ast (1.27.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     systemu (2.6.5)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -90,6 +93,7 @@ PLATFORMS
 
 DEPENDENCIES
   exponential-backoff
+  mocha
   novu!
   rake (~> 13.0)
   rspec

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use the library, first initialize the client with your API token:
 ```ruby
 require 'novu'
 
-client = Novu::Client.new('YOUR_NOVU_API_TOKEN')
+client = Novu::Client.new(access_token: 'YOUR_NOVU_API_TOKEN')
 ```
 
 You can then call methods on the client to interact with the Novu API:

--- a/README.md
+++ b/README.md
@@ -841,6 +841,44 @@ client.delete_topic('<insert-topic-key>')
 client.subscriber_topic('<insert-topic-key>', '<insert-externalSubscriberId>')
 ```
 
+### Idempotent Request
+
+This SDK allows you to perform idempotent requests, that is safely retrying requests without accidentally performing the same operation twice. 
+To achieve this, provide an `idempotency_key` argument during initialization of the NOVU client. We strongly recommend that you use [UUID](https://datatracker.ietf.org/doc/html/rfc4122) format when you're generating your idempotency key. 
+
+```ruby
+client = Novu::Client.new(
+  access_token: '<your-novu-api_key>', 
+  idempotency_key: '<your-idempotency-key>'
+)
+```
+
+### Exponential Retry Mechanism
+
+You can configure this SDK to retry failed requests. This is done by using [Exponential backoff strategy](https://en.wikipedia.org/wiki/Exponential_backoff). It is a common algorithm for retrying requests. The retries gradually extend the waiting time until reaching a specific limit. The concept is to prevent overloading the server with simultaneous requests once it is back online, especially in cases of temporary downtime. 
+
+```ruby
+client = Novu::Client.new(
+  access_token: '<your-novu-api_key>', 
+  idempotency_key: '<your-idempotency-key>',
+  enable_retry: true, # it is disabled by default,
+  retry_config: {
+    max_retries: 3, 
+    initial_delay: 4, 
+    max_delay: 60
+  }
+)
+```
+
+## The retry configuration is explained in the following table:
+| Options       | Detail                                                             | Default Value   |  Data Type |
+| ------------- | -------------------------------------------------------------------| --------------- |  --------- |
+| max_retries   | Specifies total number of retries to perform in case of failure    | 1               |   Integer  |
+| initial_delay | Specifies the minimum time to wait before retrying (in seconds)    | 4               |   Integer  |
+| max_delay     | Specifies the maximum time to wait before retrying (in seconds)    | 60              |   Integer  |
+| enable_retry  | enabling/disable the Exponential Retry mechanism                   | false           |   Boolean  |
+
+
 ### For more information about these methods and their parameters, see the [API documentation](https://docs.novu.co/api-reference).
 
 ## Contributing

--- a/lib/novu.rb
+++ b/lib/novu.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/hash"
+require "exponential_backoff"
 require "httparty"
 require_relative "novu/version"
 require_relative "novu/client"
+require "uuid"
 
 module Novu
   # class Error < StandardError; end

--- a/lib/novu/api/connection.rb
+++ b/lib/novu/api/connection.rb
@@ -38,15 +38,14 @@ module Novu
         end
 
         response = self.class.send(http_method, path, options)
-        puts response.code, response.code == 401
+
         if  ! [401, 403, 409, 500, 502, 503, 504].include?(response.code) && ! @enable_retry
           response
         elsif @enable_retry
-          @retry_attempts += 1
-
-          puts "retrying requests now....  #{@retry_attempts}"
     
           if @retry_attempts < @max_retries
+            @retry_attempts += 1
+
             @backoff.intervals.each do |interval|
               sleep(interval)
               request(http_method, path, options)

--- a/lib/novu/api/connection.rb
+++ b/lib/novu/api/connection.rb
@@ -27,6 +27,12 @@ module Novu
       private
 
       def request(http_method, path, options)
+
+        if http_method.to_s == 'post' || http_method.to_s == 'patch'
+          self.class.default_options[:headers].merge!({ "Idempotency-Key" => "#{@idempotency_key.to_s.strip}"  }) 
+        end
+
+        # puts self.class.default_options, http_method, http_method.to_s == 'patch'
         response = self.class.send(http_method, path, options)
         puts response.code
         if response.code < 500

--- a/lib/novu/client.rb
+++ b/lib/novu/client.rb
@@ -44,6 +44,13 @@ module Novu
 
     attr_accessor :enable_retry, :max_retries, :initial_delay, :max_delay, :idempotency_key
 
+    # @param `access_token` [String]
+    # @param `idempotency_key` [String]
+    # @param `enable_retry` [Boolean]
+    # @param `retry_config` [Hash]
+    #           - max_retries [Integer]
+    #           - initial_delay [Integer]
+    #           - max_delay [Integer]
     def initialize(access_token: nil, idempotency_key: nil, enable_retry: false, retry_config: {} )
       raise ArgumentError, "Api Key cannot be blank or nil" if access_token.blank?
 
@@ -71,8 +78,12 @@ module Novu
 
     private 
 
+    # @retun [Hash]
+    #   - max_retries [Integer]
+    #   - initial_delay [Integer]
+    #   - max_delay [Integer]
     def defaults_retry_config
-      { max_retries: 3, initial_delay: 4.0, max_delay: 60.0 }
+      { max_retries: 1, initial_delay: 4, max_delay: 60 }
     end
   end
 end

--- a/lib/novu/client.rb
+++ b/lib/novu/client.rb
@@ -42,10 +42,15 @@ module Novu
     base_uri "https://api.novu.co/v1"
     format :json
 
-    attr_accessor :enable_retry, :max_retries, :initial_delay, :max_delay
+    attr_accessor :enable_retry, :max_retries, :initial_delay, :max_delay, :idempotency_key
 
-    def initialize(access_token: nil, enable_retry: false, retry_config: {} )
+    def initialize(access_token: nil, idempotency_key: nil, enable_retry: false, retry_config: {} )
       raise ArgumentError, "Api Key cannot be blank or nil" if access_token.blank?
+
+      # if 
+      @idempotency_key = idempotency_key.blank? ? UUID.new.generate : idempotency_key
+
+      puts "idempotency_key #{@idempotency_key}"
 
       @enable_retry = enable_retry
       @access_token = access_token.to_s.strip
@@ -57,6 +62,7 @@ module Novu
       @max_delay = retry_config[:max_delay]
 
       self.class.default_options.merge!(headers: { "Authorization" => "ApiKey #{@access_token}" })
+      # self.class.default_options.merge!(headers: {  })
 
       # Configure the exponential backoff - specifying initial and maximal delays, default is 4s and 60s respectively
       if @enable_retry

--- a/lib/novu/client.rb
+++ b/lib/novu/client.rb
@@ -47,10 +47,7 @@ module Novu
     def initialize(access_token: nil, idempotency_key: nil, enable_retry: false, retry_config: {} )
       raise ArgumentError, "Api Key cannot be blank or nil" if access_token.blank?
 
-      # if 
       @idempotency_key = idempotency_key.blank? ? UUID.new.generate : idempotency_key
-
-      puts "idempotency_key #{@idempotency_key}"
 
       @enable_retry = enable_retry
       @access_token = access_token.to_s.strip
@@ -62,7 +59,6 @@ module Novu
       @max_delay = retry_config[:max_delay]
 
       self.class.default_options.merge!(headers: { "Authorization" => "ApiKey #{@access_token}" })
-      # self.class.default_options.merge!(headers: {  })
 
       # Configure the exponential backoff - specifying initial and maximal delays, default is 4s and 60s respectively
       if @enable_retry

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,10 @@ require 'webmock/rspec'
 require_relative "../lib/novu"
 
 RSpec.configure do |config|
+  config.expect_with :rspec, :test_unit
+  config.mock_with :mocha
+  config.pattern = '**/*.spec'
+  
   # # Enable flags like --only-failures and --next-failure
   # config.example_status_persistence_file_path = ".rspec_status"
 

--- a/test/unit/client_spec.rb
+++ b/test/unit/client_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/novu"
+
+describe Novu::Client do
+
+  let(:access_token) { "1234567890" }
+  let(:idempotency_key1) { "489e2e70-50be-013c-faf9-38e85644422a" }
+  let(:idempotency_key2) { "99893-50be-5d3c-k109-8920564sd22a" }
+
+  let(:body) { 
+    {
+      firstName: "John",
+      lastName: "Doe"
+    }.to_json
+  }
+
+  let(:response_body) {
+    {
+      _id: "63f71b3ef067290fa669106d"
+    }.to_json
+  }
+
+  it "enables exponential retry mechanism" do
+    client = Novu::Client.new(
+      access_token: access_token, 
+      idempotency_key: idempotency_key1, 
+      enable_retry: true, 
+      retry_config: { max_retries: 3 }
+    )
+    client.expects(:create_subscriber).returns(StandardError)
+
+    result = client.create_subscriber(body)
+    assert_equal(StandardError, result)
+  end
+
+  it "failed request not retried" do
+    client = Novu::Client.new(access_token: access_token)
+    client.expects(:create_subscriber).returns(status: 401)
+
+    result = client.create_subscriber(body)
+    assert_equal(401, result[:status])
+  end
+
+  it "performs idempotent request with no duplicate result" do
+
+    client = Novu::Client.new(access_token: access_token, idempotency_key: idempotency_key2)
+    client.expects(:create_subscriber).at_most(3).returns(status: 201, body: response_body)
+    result1 = client.create_subscriber(body)
+    result2 = client.create_subscriber(body)
+    result3 = client.create_subscriber(body)
+
+    assert_equal(result2[:body], result1[:body])
+    assert_equal(result2[:body], result3[:body])
+    assert_equal(result1[:body], result3[:body])
+  end
+end


### PR DESCRIPTION
This PR added the following features to the SDK:
1. Exponential Retry Mechanism: Failed requests can be retried with configurable paramters
```ruby
client = Novu::Client.new(
  access_token: '<your-novu-api_key>', 
  idempotency_key: '<your-idempotency-key>',
  enable_retry: true, # it is disabled by default,
  retry_config: {
    max_retries: 3, 
    initial_delay: 4, 
    max_delay: 60
  }
)
```

2. Idempotency Key Provisioning: 
```ruby
client = Novu::Client.new(
  access_token: '<your-novu-api_key>', 
  idempotency_key: '<your-idempotency-key>'
)
```

3. Adds Named Argument to client initialization:
Before:
```ruby
client = Novu::Client.new('<your-novu-api_key>')
```

Now:
```ruby
client = Novu::Client.new(access_token: '<your-novu-api_key>')
```
