### PR TITLE
Add backend_url option to client initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,6 +934,17 @@ client = Novu::Client.new(
 | enable_retry  | enabling/disable the Exponential Retry mechanism                   | false           |   Boolean  |
 
 
+### Custom backend URL
+
+To use a custom backend URL, for example to be able to use the EU Novu API, you can pass a custom `backend_url` when initializing the client.
+
+```ruby
+client = Novu::Client.new(
+  access_token: '<your-novu-api_key>', 
+  backend_url: 'https://eu.api.novu.co/v1'
+)
+```
+
 ### For more information about these methods and their parameters, see the [API documentation](https://docs.novu.co/api-reference).
 
 ## Contributing

--- a/lib/novu/client.rb
+++ b/lib/novu/client.rb
@@ -42,7 +42,6 @@ module Novu
     include Novu::Api::Tenants
     include Novu::Api::Topics
 
-    base_uri "https://api.novu.co/v1"
     format :json
 
     attr_accessor :enable_retry, :max_retries, :initial_delay, :max_delay, :idempotency_key
@@ -54,7 +53,7 @@ module Novu
     #           - max_retries [Integer]
     #           - initial_delay [Integer]
     #           - max_delay [Integer]
-    def initialize(access_token: nil, idempotency_key: nil, enable_retry: false, retry_config: {} )
+    def initialize(access_token: nil, idempotency_key: nil, enable_retry: false, retry_config: {}, backend_url: "https://api.novu.co/v1")
       raise ArgumentError, "Api Key cannot be blank or nil" if access_token.blank?
 
       @idempotency_key = idempotency_key.blank? ? UUID.new.generate : idempotency_key
@@ -67,6 +66,8 @@ module Novu
       @max_retries = retry_config[:max_retries]
       @initial_delay = retry_config[:initial_delay]
       @max_delay = retry_config[:max_delay]
+
+      self.base_uri = backend_url
 
       self.class.default_options.merge!(headers: { 
 					"Authorization" => "ApiKey #{@access_token}",


### PR DESCRIPTION
To use a custom backend URL, for example to be able to use the EU Novu API, you can pass a custom `backend_url` when initializing the client.

```ruby
client = Novu::Client.new(
  access_token: '<your-novu-api_key>', 
  backend_url: 'https://eu.api.novu.co/v1'
)
```